### PR TITLE
fix: replace Math.random() with crypto.randomUUID() for secure ID gen…

### DIFF
--- a/app/components/Toast.tsx
+++ b/app/components/Toast.tsx
@@ -124,7 +124,12 @@ export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ childre
   const [toasts, setToasts] = useState<ToastProps[]>([])
 
   const showToast = (toast: Omit<ToastProps, 'id' | 'onClose'>) => {
-    const id = Math.random().toString(36).substr(2, 9)
+    // Use crypto.randomUUID() for cryptographically secure, collision-resistant ID generation
+    // Fallback to timestamp + random for older browsers that don't support crypto.randomUUID()
+    const id = typeof crypto !== 'undefined' && crypto.randomUUID 
+      ? crypto.randomUUID() 
+      : `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
+    
     const newToast: ToastProps = {
       ...toast,
       id,

--- a/app/risk-management/register/[riskId]/page.tsx
+++ b/app/risk-management/register/[riskId]/page.tsx
@@ -433,6 +433,15 @@ export default function RiskInformation() {
     }
   }
 
+  // Type utilities for safe field change handling
+  type StringFields = {
+    [K in keyof RiskDetails]: RiskDetails[K] extends string ? K : never
+  }[keyof RiskDetails]
+
+  type NumberFields = {
+    [K in keyof RiskDetails]: RiskDetails[K] extends number ? K : never
+  }[keyof RiskDetails]
+
   // Type-safe field change handler that accepts appropriate value types for each field
   const handleFieldChange = <K extends keyof RiskDetails>(
     field: K, 
@@ -445,19 +454,21 @@ export default function RiskInformation() {
     })
   }
 
-  // Specialized handlers for different input types
-  const handleStringFieldChange = (field: keyof RiskDetails, value: string) => {
-    handleFieldChange(field, value as RiskDetails[keyof RiskDetails])
+  // Type-safe string field change handler
+  const handleStringFieldChange = (field: StringFields, value: string) => {
+    handleFieldChange(field, value)
   }
 
-  const handleNumberFieldChange = (field: keyof RiskDetails, value: number) => {
-    handleFieldChange(field, value as RiskDetails[keyof RiskDetails])
+  // Type-safe number field change handler
+  const handleNumberFieldChange = (field: NumberFields, value: number) => {
+    handleFieldChange(field, value)
   }
 
-  const handleDateFieldChange = (field: keyof RiskDetails, value: string) => {
+  // Type-safe date field change handler (dates are stored as strings)
+  const handleDateFieldChange = (field: StringFields, value: string) => {
     // Ensure date is in proper format for storage
     const formattedDate = value ? value : ''
-    handleFieldChange(field, formattedDate as RiskDetails[keyof RiskDetails])
+    handleFieldChange(field, formattedDate)
   }
 
   if (loading) {


### PR DESCRIPTION
…eration - Replace insecure Math.random() ID generation with cryptographically secure crypto.randomUUID() - Add fallback for older browsers using timestamp + random - Improve collision resistance and security for toast notifications - Follow RFC 4122 UUID v4 standard for unique identifier generation