### PR TITLE
Improve code clarity: rename getStatusColor to getClosureStatusColor …

### DIFF
--- a/app/risk-management/treatments/[riskId]/[id]/page.tsx
+++ b/app/risk-management/treatments/[riskId]/[id]/page.tsx
@@ -91,7 +91,7 @@ export default function TreatmentInformation() {
     }
 
     fetchData()
-  }, [params.riskId, params.id]) // Removed showToast from dependencies
+  }, [params.riskId, params.id])
 
   const formatDate = (dateString: string) => {
     if (!dateString) return '-'
@@ -102,7 +102,7 @@ export default function TreatmentInformation() {
     })
   }
 
-  const getStatusColor = (status: string) => {
+  const getClosureStatusColor = (status: string) => {
     switch (status.toLowerCase()) {
       case 'approved':
         return 'bg-green-100 text-green-800'
@@ -242,7 +242,7 @@ export default function TreatmentInformation() {
                     <label className="block text-sm font-medium text-gray-700 mb-1">
                       Closure Approval
                     </label>
-                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getStatusColor(treatment.closureApproval)}`}>
+                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getClosureStatusColor(treatment.closureApproval)}`}>
                       {treatment.closureApproval}
                     </span>
                   </div>

--- a/app/risk-management/treatments/[riskId]/page.tsx
+++ b/app/risk-management/treatments/[riskId]/page.tsx
@@ -306,7 +306,7 @@ export default function RiskTreatments() {
     // TODO: Implement CSV export
   }
 
-  const getStatusColor = (status: string) => {
+  const getClosureStatusColor = (status: string) => {
     switch (status.toLowerCase()) {
       case 'approved':
         return 'bg-green-100 text-green-800'
@@ -374,7 +374,7 @@ export default function RiskTreatments() {
       }
       if (col.key === 'closureApproval') {
         return (
-          <span className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(value)}`}>
+          <span className={`px-2 py-1 rounded-full text-xs font-medium ${getClosureStatusColor(value)}`}>
             {value}
           </span>
         )


### PR DESCRIPTION
…for closure approval functions and remove misleading comment

- Rename getStatusColor to getClosureStatusColor in treatment information pages to clarify purpose
- Remove misleading comment about showToast dependencies that was never actually a dependency
- Maintain consistent naming: getStatusColor for risk phases, getClosureStatusColor for closure approvals