### PR TITLE
feat: add global SOA controls search function by risk ID

### DIFF
--- a/SOA_FUNCTION_DOCUMENTATION.md
+++ b/SOA_FUNCTION_DOCUMENTATION.md
@@ -1,0 +1,125 @@
+# SOA Controls by Risk ID Function
+
+## Overview
+
+A global function that searches the Statement of Applicability (SOA) controls database to find all controls that are related to a specific risk ID.
+
+**Important**: This function is located in `lib/server-utils.ts` (not `lib/utils.ts`) because it requires MongoDB access and can only be used on the server side. The separation ensures that client-side components can import from `lib/utils.ts` without encountering Node.js-specific dependency issues.
+
+## Function Signature
+
+```typescript
+async function findSoAControlsByRiskId(riskId: string): Promise<SoAControlResult[]>
+```
+
+## Parameters
+
+- **riskId** (string): The risk ID to search for (e.g., "RISK-001", "RISK-002", etc.)
+
+## Return Type
+
+```typescript
+interface SoAControlResult {
+  id: string    // Control ID (e.g., "A.5.1", "A.8.7")
+  title: string // Control title (e.g., "Policies for information security")
+}
+```
+
+## Usage Examples
+
+### TypeScript/JavaScript (using import)
+
+```typescript
+import { findSoAControlsByRiskId } from '@/lib/server-utils'
+
+// Find all SOA controls related to RISK-001
+const controls = await findSoAControlsByRiskId('RISK-001')
+
+console.log(`Found ${controls.length} controls`)
+controls.forEach(control => {
+  console.log(`${control.id}: ${control.title}`)
+})
+```
+
+### API Endpoint
+
+You can also use the REST API endpoint:
+
+```
+GET /api/soa-controls/by-risk/[riskId]
+```
+
+Example:
+```
+GET /api/soa-controls/by-risk/RISK-001
+```
+
+Response:
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "id": "A.5.1",
+      "title": "Policies for information security"
+    },
+    {
+      "id": "A.5.2", 
+      "title": "Information security roles and responsibilities"
+    }
+  ],
+  "count": 25,
+  "riskId": "RISK-001"
+}
+```
+
+### Node.js Script
+
+You can test the function using the provided test script:
+
+```bash
+node test-soa-function.js RISK-001
+```
+
+## Database Schema
+
+The function searches the `soa_controls` collection where each document has the following relevant fields:
+
+- `id`: Control identifier (e.g., "A.5.1")
+- `title`: Control title
+- `relatedRisks`: Array of risk IDs that this control addresses
+
+## Error Handling
+
+The function will throw an error if:
+- No risk ID is provided
+- Risk ID is not a string
+- Database connection fails
+- Query execution fails
+
+## Performance Notes
+
+- The function uses MongoDB's indexed search on the `relatedRisks` field
+- Results are limited to only the `id` and `title` fields for performance
+- No pagination is implemented (returns all matching controls)
+
+## Implementation Details
+
+- **Location**: `lib/server-utils.ts`
+- **Database**: MongoDB collection `soa_controls`
+- **Connection**: Uses the global MongoDB client promise from `lib/mongodb.ts`
+- **Security**: No authentication required (internal function)
+
+## Testing
+
+Run the test suite:
+```bash
+# Test with existing risk ID
+node test-soa-function.js RISK-001
+
+# Test with non-existent risk ID  
+node test-soa-function.js RISK-999
+
+# Test API endpoint
+curl http://localhost:3001/api/soa-controls/by-risk/RISK-001
+```

--- a/app/api/soa-controls/by-risk/[riskId]/route.ts
+++ b/app/api/soa-controls/by-risk/[riskId]/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { findSoAControlsByRiskId } from '../../../../../lib/server-utils'
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ riskId: string }> }
+) {
+  try {
+    const { riskId } = await context.params
+    
+    if (!riskId) {
+      return NextResponse.json({
+        success: false,
+        error: 'Risk ID parameter is required'
+      }, { status: 400 })
+    }
+
+    const controls = await findSoAControlsByRiskId(riskId)
+    
+    return NextResponse.json({
+      success: true,
+      data: controls,
+      count: controls.length,
+      riskId: riskId
+    })
+  } catch (error) {
+    console.error('Error finding SOA controls by risk ID:', error)
+    return NextResponse.json({
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to find SOA controls'
+    }, { status: 500 })
+  }
+}

--- a/lib/server-utils.ts
+++ b/lib/server-utils.ts
@@ -1,0 +1,41 @@
+import clientPromise from './mongodb'
+
+/**
+ * Interface for SOA Control results returned by findSoAControlsByRiskId
+ */
+export interface SoAControlResult {
+  id: string
+  title: string
+}
+
+/**
+ * Global function to find SOA controls that contain a specific risk ID in their relatedRisks field
+ * @param riskId - The risk ID to search for in SOA controls (e.g., "RISK-001")
+ * @returns Promise<SoAControlResult[]> - Array of control objects with id and title
+ */
+export async function findSoAControlsByRiskId(riskId: string): Promise<SoAControlResult[]> {
+  if (!riskId || typeof riskId !== 'string') {
+    throw new Error('Risk ID must be a non-empty string')
+  }
+
+  try {
+    const client = await clientPromise()
+    const db = client.db('cycorgi')
+    const collection = db.collection('soa_controls')
+    
+    // Find all controls where the relatedRisks array contains the specified riskId
+    const controls = await collection.find(
+      { relatedRisks: riskId },
+      { projection: { id: 1, title: 1, _id: 0 } }
+    ).toArray()
+    
+    // Return only the id and title fields as specified
+    return controls.map(control => ({
+      id: control.id,
+      title: control.title
+    }))
+  } catch (error) {
+    console.error('Error finding SOA controls by risk ID:', error)
+    throw new Error(`Failed to find SOA controls for risk ID: ${riskId}`)
+  }
+}

--- a/lib/server-utils.ts
+++ b/lib/server-utils.ts
@@ -33,7 +33,7 @@ export async function findSoAControlsByRiskId(riskId: string): Promise<SoAContro
     return controls.map(control => ({
       id: control.id,
       title: control.title
-    }))
+    return controls
   } catch (error) {
     console.error('Error finding SOA controls by risk ID:', error)
     throw new Error(`Failed to find SOA controls for risk ID: ${riskId}`)

--- a/lib/server-utils.ts
+++ b/lib/server-utils.ts
@@ -19,7 +19,7 @@ export async function findSoAControlsByRiskId(riskId: string): Promise<SoAContro
   }
 
   try {
-    const client = await clientPromise()
+    const client = await clientPromise
     const db = client.db('cycorgi')
     const collection = db.collection('soa_controls')
     

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -217,4 +217,4 @@ export function mapAssetIdsToNames(assetIds: AssetIdInput, informationAssets: Ar
 export function formatOptionText(...parts: unknown[]): string {
   const concatenated = parts.map(part => String(part || '')).join('')
   return escapeHtml(concatenated)
-} 
+}

--- a/test-soa-function.js
+++ b/test-soa-function.js
@@ -19,6 +19,9 @@ async function findSoAControlsByRiskId(riskId) {
     throw new Error('Risk ID must be a non-empty string');
   }
 
+  if (!process.env.MONGODB_URI) {
+    throw new Error('MONGODB_URI environment variable is not set');
+  }
   const client = new MongoClient(process.env.MONGODB_URI);
   
   try {

--- a/test-soa-function.js
+++ b/test-soa-function.js
@@ -1,0 +1,78 @@
+/**
+ * Test script to demonstrate the findSoAControlsByRiskId function
+ * 
+ * Usage:
+ * node test-soa-function.js [riskId]
+ * 
+ * Example:
+ * node test-soa-function.js RISK-001
+ */
+
+require('dotenv').config({ path: '.env.local' });
+
+// Import the function - in a real JS file, you'd need to transpile the TypeScript
+// For demo purposes, here's a JS version of the function
+const { MongoClient } = require('mongodb');
+
+async function findSoAControlsByRiskId(riskId) {
+  if (!riskId || typeof riskId !== 'string') {
+    throw new Error('Risk ID must be a non-empty string');
+  }
+
+  const client = new MongoClient(process.env.MONGODB_URI);
+  
+  try {
+    await client.connect();
+    const db = client.db('cycorgi');
+    const collection = db.collection('soa_controls');
+    
+    // Find all controls where the relatedRisks array contains the specified riskId
+    const controls = await collection.find(
+      { relatedRisks: riskId },
+      { projection: { id: 1, title: 1, _id: 0 } }
+    ).toArray();
+    
+    // Return only the id and title fields as specified
+    return controls.map(control => ({
+      id: control.id,
+      title: control.title
+    }));
+  } catch (error) {
+    console.error('Error finding SOA controls by risk ID:', error);
+    throw new Error(`Failed to find SOA controls for risk ID: ${riskId}`);
+  } finally {
+    await client.close();
+  }
+}
+
+async function testFunction() {
+  const riskId = process.argv[2] || 'RISK-001';
+  
+  console.log(`🔍 Testing findSoAControlsByRiskId with riskId: ${riskId}`);
+  console.log('='.repeat(60));
+  
+  try {
+    const controls = await findSoAControlsByRiskId(riskId);
+    
+    if (controls.length === 0) {
+      console.log(`❌ No SOA controls found for risk ID: ${riskId}`);
+    } else {
+      console.log(`✅ Found ${controls.length} SOA controls for risk ID: ${riskId}`);
+      console.log('\nResults:');
+      controls.forEach((control, index) => {
+        console.log(`${index + 1}. ID: ${control.id}`);
+        console.log(`   Title: ${control.title}`);
+        console.log('');
+      });
+    }
+  } catch (error) {
+    console.error('❌ Error:', error.message);
+  }
+}
+
+// Run the test if this file is executed directly
+if (require.main === module) {
+  testFunction().catch(console.error);
+}
+
+module.exports = { findSoAControlsByRiskId };


### PR DESCRIPTION
- Add findSoAControlsByRiskId function in lib/server-utils.ts
- Create REST API endpoint /api/soa-controls/by-risk/[riskId]
- Separate server-side utilities from client-safe utils to fix MongoDB import issues
- Add comprehensive documentation for the new function
- Include test script for function verification
- Function searches soa_controls collection for controls related to specific risk IDs
- Returns array of {id, title} objects for matching controls
- Resolves client-side MongoDB import conflicts in Sidebar component