### PR TITLE
Fix GitHub Actions Terraform deployment - Disable interactive input t…

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -72,4 +72,5 @@ jobs:
         working-directory: infra/environments/dev
         env:
           TF_VAR_image_tag: ${{ steps.vars.outputs.tag }}
-        run: terraform apply -auto-approve -lock-timeout=120s
+          TF_INPUT: "false"
+        run: terraform apply -auto-approve -lock-timeout=120s -input=false

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -15,12 +15,6 @@ terraform {
   required_version = ">= 1.7.0"
 }
 
-variable "mongodb_uri" {
-  description = "MongoDB connection URI"
-  type        = string
-  sensitive   = true
-}
-
 variable "image_tag" {
   description = "Docker image tag for the Cloud Run service"
   type        = string


### PR DESCRIPTION
…o prevent workflow hanging - Remove mongodb_uri environment variable dependency - Add TF_INPUT=false and -input=false flags for non-interactive deployment